### PR TITLE
added extra argument --use_encoded_layer

### DIFF
--- a/BERT/encoder/arg_input.py
+++ b/BERT/encoder/arg_input.py
@@ -27,7 +27,8 @@ def get_args():
                       help='do_test only')
   parser.add_argument('--metric_option', type=str, required=True,
                       help='cosine or entailment')
-  
+  parser.add_argument('--use_encoded_layer', action = 'store_true', 
+		      help='allows user to use second to last layer in the BERT model as vector')
   parser.add_argument('--write_score', type=str, default=None,
                       help='write out score for 2 GO vectors') 
 

--- a/BERT/encoder/encoder_model.py
+++ b/BERT/encoder/encoder_model.py
@@ -233,9 +233,18 @@ class encoder_model (nn.Module) :
     # used as as the "sentence vector". Note that this only makes sense because
     # the entire model is fine-tuned.
     # https://github.com/huggingface/pytorch-pretrained-BERT/blob/master/examples/extract_features.py#L95
-
-    _ , pooled_output = self.bert_lm_sentence.bert (input_ids=label_desc, token_type_ids=None, attention_mask=label_mask, output_all_encoded_layers=False)
-    return pooled_output # [batch_size, hidden_size]
+    if self.args.use_encoded_layer:
+    	encoded_layer , _  = self.bert_lm_sentence.bert (input_ids=label_desc, token_type_ids=None, attention_mask=label_mask, output_all_encoded_layers=True)
+    	second_tolast = encoded_layer[-2]
+    	second_tolast[label_mask == 0] = 0
+    	cuda_second_layer = (second_tolast).type(torch.FloatTensor).cuda()
+    	encode_sum = torch.sum(cuda_second_layer, dim = 1).cuda()
+    	label_sum = torch.sum(label_mask.cuda(), dim=1).unsqueeze(0).transpose(0,1).type(torch.FloatTensor).cuda()
+    	go_vectors = encode_sum/label_sum
+    	return go_vectors
+    else:
+    	_ , pooled_output  = self.bert_lm_sentence.bert (input_ids=label_desc, token_type_ids=None, attention_mask=label_mask, output_all_encoded_layers=False)
+    	return pooled_output # [batch_size, hidden_size]
 
   def train_label (self, train_dataloader, num_train_optimization_steps, dev_dataloader=None):
 


### PR DESCRIPTION
uses the second to last layer of the BERT model
This code uses the second to last layer of the BERT model to get vectors for each GO term, based on how bert as a service gets vector representation for sentences.
Signed-off-by: auppunda <auppunda@gmail.com>